### PR TITLE
Update Fetching Track Data from Spotify API

### DIFF
--- a/client/src/components/App/App.css
+++ b/client/src/components/App/App.css
@@ -15,5 +15,7 @@
   --txt-light: #b3c1d8;
   --txt-dark: #314067;
   --light-border: #ccc;
-  --background-color: rgb(250, 249, 249);
+  --elements-pink: rgb(214, 112, 151);
+  --elements-darkpink: rgb(178, 84, 120);
+  --background-color: rgb(243, 240, 240);
 }

--- a/client/src/components/App/App.jsx
+++ b/client/src/components/App/App.jsx
@@ -53,7 +53,7 @@ function App() {
                 </Protected>
               }
             />
-            <Route path="recommend/playlist/:playlistId/:originalPlaylistId" element=
+            <Route path="/user/:playlistId" element=
               {
                 <Protected token={token}>
                   <UserPlaylistDetail />

--- a/client/src/components/Dropdown/Dropdown.jsx
+++ b/client/src/components/Dropdown/Dropdown.jsx
@@ -1,25 +1,28 @@
 import React from 'react'
 import { useState, useEffect } from 'react'
 import {IoMdArrowDropdown, IoMdArrowDropup} from 'react-icons/io'
-import { sortOptionsTracks } from 'utils/playlist'
+import Tracks from 'utils/tracks'
 import "./Dropdown.css"
 
 function Dropdown({
   options,
   selected,
   setSelected,
-  setCurrentAddPlaylist
+  setCurrentAddPlaylist,
+  refresh
 }) {
   const [isActive, setIsActive] = useState(false)
+  const track = new Tracks()
 
   useEffect(() => {
     if (options.length === 0) {
-      setSelected("No playlists found")
+      setSelected("No playlist available")
     } else {
       /* sort options array alphabetically */
-      sortOptionsTracks(options)
+      setSelected("Add a playlist")
+      track.sortOptionsTracks(options)
     }
-  }, [])
+  }, [refresh])
 
   return (
     <div className="dropdown">
@@ -49,3 +52,4 @@ function Dropdown({
 }
 
 export default Dropdown
+

--- a/client/src/components/GenreContainer/GenreContainer.jsx
+++ b/client/src/components/GenreContainer/GenreContainer.jsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { useState, useEffect } from 'react'
+import { getArtistDetail } from '../../utils/spotify'
+
+function GenreContainer({
+  tracks
+}) {
+  const [genreArray, setGenreArray] = useState([])
+
+  useEffect(() => {
+    const getArtistGenres = async () => {
+      /* creates array of artist ids as a parameter for Spotify API */
+      let artistArray = []
+      tracks.forEach(item => {
+        const artists = item.track.artists
+        artists.forEach(item => {
+          artistArray.push(item.id)
+        })
+      })
+  
+      while (artistArray.length > 0) {
+        /* requests artist information in increments of 50 */
+        let newArray = genreArray
+        let artistString = artistArray.splice(0, 50).join(',')
+        const { data } = await getArtistDetail(artistString)
+        
+        /* counts number of times each genre appears */
+        data.artists.forEach(item => {
+          item.genres.forEach(genre => {
+            let found = false
+            newArray.forEach(item => {
+              if (item.genre === genre) {
+                item.count += 1
+                found = true
+              }
+            })
+            if (!found) {
+              const newGenre = { genre: genre, count: 0}
+              newArray.push(newGenre)
+            }
+          })
+        })
+        newArray.sort((a, b) => {
+          return b.count - a.count
+        })
+        setGenreArray(oldArray => [...oldArray, newArray])
+      }
+    }
+    getArtistGenres()
+  }, [])
+  return (
+    <div className="genre-container">
+      <div className="genres">
+        <h2>Top Genres in Playlist</h2>
+        {genreArray.slice(0, 5).map((item, idx) => {
+          return <p key={idx}>{item.genre}</p>
+        })}
+      </div>
+    </div>
+  )
+}
+
+export default GenreContainer

--- a/client/src/components/GenreContainer/GenreContainer.jsx
+++ b/client/src/components/GenreContainer/GenreContainer.jsx
@@ -6,17 +6,16 @@ function GenreContainer({
   tracks
 }) {
   const [genreArray, setGenreArray] = useState([])
+  const [topFiveGenres, setTopFiveGenres] = useState([])
 
   useEffect(() => {
     const getArtistGenres = async () => {
       /* creates array of artist ids as a parameter for Spotify API */
-      let artistArray = []
-      tracks.forEach(item => {
-        const artists = item.track.artists
-        artists.forEach(item => {
-          artistArray.push(item.id)
+      const artistArray = tracks.map(item => (
+        item.track.artists.map(artist => {
+          return artist.id
         })
-      })
+      )).flat()
   
       while (artistArray.length > 0) {
         /* requests artist information in increments of 50 */
@@ -48,11 +47,15 @@ function GenreContainer({
     }
     getArtistGenres()
   }, [])
+
+  useState(() => {
+    setTopFiveGenres(genreArray.slice(0, 5))
+  }, [genreArray])
   return (
     <div className="genre-container">
       <div className="genres">
         <h2>Top Genres in Playlist</h2>
-        {genreArray.slice(0, 5).map((item, idx) => {
+        {topFiveGenres.map((item, idx) => {
           return <p key={idx}>{item.genre}</p>
         })}
       </div>

--- a/client/src/components/GenreContainer/GenreContainer.jsx
+++ b/client/src/components/GenreContainer/GenreContainer.jsx
@@ -11,7 +11,7 @@ function GenreContainer({
   useEffect(() => {
     const getArtistGenres = async () => {
       /* creates array of artist ids as a parameter for Spotify API */
-      const artistArray = tracks.map(item => (
+      const artistArray = tracks.flatMap(item => (
         item.track.artists.map(artist => {
           return artist.id
         })

--- a/client/src/components/PlaylistCard/PlaylistCard.css
+++ b/client/src/components/PlaylistCard/PlaylistCard.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   background: var(--background-color);
-  padding: 10px 0 0 10px;
+  padding: 10px 0px 0px 10px;
   border-radius: 5px;
   width: 172px;
   min-height: 250px;

--- a/client/src/components/PlaylistCard/PlaylistCard.css
+++ b/client/src/components/PlaylistCard/PlaylistCard.css
@@ -1,9 +1,8 @@
 .playlist-card {
   display: flex;
-  flex-wrap: wrap;
   flex-direction: column;
-  background: rgba(239, 236, 236, 0.529);
-  padding: 10px 0px 0px 10px;
+  background: var(--background-color);
+  padding: 10px 0 0 10px;
   border-radius: 5px;
   width: 172px;
   min-height: 250px;

--- a/client/src/components/PlaylistDetail/PlaylistDetail.css
+++ b/client/src/components/PlaylistDetail/PlaylistDetail.css
@@ -14,7 +14,7 @@
 .playlist-detail .header img {
   width: 300px;
   height: 300px;
-  box-shadow: 0 0 13px 0px rgba(1, 1, 14, 0.7);
+  box-shadow: 0px 0px 13px 0px rgba(1, 1, 14, 0.7);
 }
 
 .playlist-detail .header .playlist-header-info {
@@ -46,7 +46,7 @@
 }
 
 .playlist-detail .recommend-btn:hover, .remove-playlist-btn:hover {
-  box-shadow: 0 0 13px 0px rgba(155, 155, 161, 0.7);
+  box-shadow: 0px 0px 13px 0px rgba(155, 155, 161, 0.7);
   transform: translateY(-3px);
 }
 
@@ -61,7 +61,7 @@
 }
 
 .playlist-detail .left .details {
-  box-shadow: 0 0 13px 0px rgba(217, 217, 223, 0.7);
+  box-shadow: 0px 0px 13px 0px rgba(217, 217, 223, 0.7);
   width: 290px;
   padding: 15px 20px 5px 20px;
   border-radius: 6px;

--- a/client/src/components/PlaylistDetail/PlaylistDetail.css
+++ b/client/src/components/PlaylistDetail/PlaylistDetail.css
@@ -5,16 +5,96 @@
   min-height: 100vh;
 }
 
+.playlist-detail .header {
+  position: absolute;
+  display: flex;
+  margin: 115px 250px;
+}
+
+.playlist-detail .header img {
+  width: 300px;
+  height: 300px;
+  box-shadow: 0 0 13px 0px rgba(1, 1, 14, 0.7);
+}
+
+.playlist-detail .header .playlist-header-info {
+  margin-left: 50px;
+  margin-top: 30px;
+}
+
+.playlist-detail .buttons {
+  border-radius: 6px;
+  margin-top: 30px;
+  padding: 3px;
+}
+
+.playlist-detail .recommend-btn, .remove-playlist-btn {
+  padding: 10px 20px;
+  font-size: 1.5rem;
+  background: var(--elements-pink);
+  letter-spacing: 1px;
+  border: none;
+  color: white;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: 200ms ease-in-out;
+}
+
+.playlist-detail .remove-playlist-btn {
+  margin-left: 5px;
+  background: rgb(197, 14, 84);
+}
+
+.playlist-detail .recommend-btn:hover, .remove-playlist-btn:hover {
+  box-shadow: 0 0 13px 0px rgba(155, 155, 161, 0.7);
+  transform: translateY(-3px);
+}
+
 .playlist-detail .playlist-detail-content {
-  padding: 0% 5%;
-  margin-top: 58px;
+  padding: 270px 82px;
+  width: 80%;
+  margin: auto;
+  margin-top: 12.8%;
+  background: white;
+  display: flex;
+  border-radius: 10px;
 }
 
-.playlist-detail .playlist-card {
-  width: 500px;
+.playlist-detail .left .details {
+  box-shadow: 0 0 13px 0px rgba(217, 217, 223, 0.7);
+  width: 290px;
+  padding: 15px 20px 5px 20px;
+  border-radius: 6px;
 }
 
-.playlist-detail .playlist-card img {
-  width: 350px;
-  height: 350px;
+.playlist-detail .right {
+  margin-left: 55px;
+  display: flex;
+  flex-direction: row;
+}
+
+/* text styling */
+.playlist-detail .left .details p{
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  font-size: 16px;
+  margin-bottom: 16px;
+}
+
+.playlist-detail .left .details span{
+  font-weight: 600;
+  font-size: 15px;
+  color: black;
+}
+
+.playlist-detail p {
+  color: rgb(100, 99, 99);
+  font-size: 1.2rem;
+  letter-spacing: .3px;
+}
+
+.playlist-detail .header h2 {
+  font-weight: 500;
+  font-size: 3.3rem;
 }

--- a/client/src/components/PlaylistDetail/PlaylistDetail.jsx
+++ b/client/src/components/PlaylistDetail/PlaylistDetail.jsx
@@ -39,11 +39,9 @@ function PlaylistDetail() {
             <div className="playlist-header-info">
               <p>PLAYLIST</p>
               <h2>{playlist.name}</h2>
-              {/* <p>BY: {playlist.owner.display_name}</p> */}
               <p>{playlist.description}</p>
               <div className="buttons">
                 <Link to={`/recommend/${playlist.id}`}><button className='recommend-btn'>recommend me</button></Link>
-                {/* <button className='remove-playlist-btn' onClick={removePlaylist}>REMOVE</button> */}
               </div>
             </div>
           </div>

--- a/client/src/components/PlaylistDetail/PlaylistDetail.jsx
+++ b/client/src/components/PlaylistDetail/PlaylistDetail.jsx
@@ -33,7 +33,7 @@ function PlaylistDetail() {
     <div className="playlist-detail">
       <NavBar />
       {playlist ? 
-        <>
+        <div>
           <div className='header'>
             <img src={playlist.images[0].url} alt="Playlist Image" />
             <div className="playlist-header-info">
@@ -63,7 +63,7 @@ function PlaylistDetail() {
               <GenreContainer tracks={playlist.tracks.items}/>
             </div>
           </div>
-      </>
+      </div>
       : <h1>Loading...</h1>}
   </div>
   )

--- a/client/src/components/PlaylistDetail/PlaylistDetail.jsx
+++ b/client/src/components/PlaylistDetail/PlaylistDetail.jsx
@@ -7,6 +7,7 @@ import TrackContainer from 'components/TrackContainer/TrackContainer'
 import { Link, useNavigate } from 'react-router-dom'
 import { notifyError, notifySuccess } from 'utils/toast'
 import NavBar from 'components/NavBar/NavBar'
+import GenreContainer from 'components/GenreContainer/GenreContainer'
 import './PlaylistDetail.css'
 
 function PlaylistDetail() {
@@ -32,27 +33,41 @@ function PlaylistDetail() {
     <div className="playlist-detail">
       <NavBar />
       {playlist ? 
-        <div className='playlist-detail-content'>
-          <div className='playlist-card'>
+        <>
+          <div className='header'>
             <img src={playlist.images[0].url} alt="Playlist Image" />
-            <div className="playlist-header">
+            <div className="playlist-header-info">
+              <p>PLAYLIST</p>
               <h2>{playlist.name}</h2>
+              {/* <p>BY: {playlist.owner.display_name}</p> */}
+              <p>{playlist.description}</p>
+              <div className="buttons">
+                <Link to={`/recommend/${playlist.id}`}><button className='recommend-btn'>recommend me</button></Link>
+                {/* <button className='remove-playlist-btn' onClick={removePlaylist}>REMOVE</button> */}
+              </div>
             </div>
           </div>
-          <div className="buttons">
-            <Link to={`/recommend/${playlist.id}`}><button className='recommend'>Recommend Me</button></Link>
-            <button className='remove-playlist' onClick={removePlaylist}>Remove Playlist</button>
+          <div className='playlist-detail-content'>
+            <div className="left">
+              <div className="details">
+                <p><span>Owner</span> {playlist.owner.display_name}</p>
+                <p><span>Followers</span> {playlist.followers.total}</p>
+                <p><span>Privacy</span> {playlist.public ? 'public' : 'private'}</p>
+                <p><span>Songs</span> {playlist.tracks.total}</p>
+              </div>
+            </div>
+            <div className="right">
+              <TrackContainer 
+                tracks={playlist.tracks.items}
+                notifyError={notifyError}
+                notifySuccess={notifySuccess}
+              />
+              <GenreContainer tracks={playlist.tracks.items}/>
+            </div>
           </div>
-          <div className="tracks">
-            <TrackContainer 
-              tracks={playlist.tracks.items}
-              notifyError={notifyError}
-              notifySuccess={notifySuccess}
-            />
-          </div>
-        </div>
+      </>
       : <h1>Loading...</h1>}
-    </div>
+  </div>
   )
 }
 

--- a/client/src/components/PlaylistView/PlaylistView.css
+++ b/client/src/components/PlaylistView/PlaylistView.css
@@ -32,7 +32,7 @@
 
 .playlist-container {
   padding: 20px;
-  box-shadow: 0 0 13px 0px rgba(206, 206, 209, 0.7);
+  box-shadow: 0px 0px 13px 0px rgba(206, 206, 209, 0.7);
   background: white;
   max-height: 500px;
   overflow: auto;

--- a/client/src/components/PlaylistView/PlaylistView.css
+++ b/client/src/components/PlaylistView/PlaylistView.css
@@ -8,14 +8,14 @@
 .playlist-view .playlist-header .add-playlist-btn {
   border: none;
   background-color: transparent;
-  color: green;
+  color: var(--elements-pink);
   cursor: pointer;
   margin-left: 20px;
   transition: 200ms ease-in-out;
 }
 
 .playlist-view .playlist-header .add-playlist-btn:hover {
-  color: rgb(26, 109, 26);
+  color: var(--elements-darkpink);
 }
 
 .playlist-view .playlist-header .playlist-searchbar {
@@ -32,7 +32,7 @@
 
 .playlist-container {
   padding: 20px;
-  box-shadow: 0px 0px 13px 0px rgba(206, 206, 209, 0.7);
+  box-shadow: 0 0 13px 0px rgba(206, 206, 209, 0.7);
   background: white;
   max-height: 500px;
   overflow: auto;
@@ -50,7 +50,7 @@
   padding-left: 15px;
 }
 
-.playlist-view .playlist-container .header {
+.playlist-container .header {
   display: flex;
   width: 100%;
   justify-content: space-between;
@@ -63,6 +63,6 @@
   align-self: center;
 }
 
-.playlist-view h3 {
+.playlist-container h3 {
   font-weight: 600;
 }

--- a/client/src/components/PlaylistView/PlaylistView.jsx
+++ b/client/src/components/PlaylistView/PlaylistView.jsx
@@ -8,6 +8,8 @@ import { addPlaylistToProfile } from 'utils/playlist'
 import { AiFillPlusCircle } from "react-icons/ai";
 import { Tooltip  } from '@mui/material'
 import ReactLoading from 'react-loading'
+import Similarity from 'utils/similarity'
+import Tracks from 'utils/tracks'
 import './PlaylistView.css'
 
 function PlaylistView({
@@ -25,6 +27,8 @@ function PlaylistView({
   setRefresh
 }) {
   const [isLoading, setIsLoading] = useState(false)
+  const similar = new Similarity()
+  const track = new Tracks()
 
   const handleAddPlaylistOnClick = () => {
     const addPlaylist = async () => {
@@ -35,10 +39,9 @@ function PlaylistView({
       
       /* create string of track Ids to use in Spotify API */
       let trackIdArray = []
-      const tracks = data.tracks.items
+      const tracks = await track.getAllPlaylistTracks(data.id)
       tracks.forEach(item => {
-        const id = item.track.id
-        trackIdArray.push(id)
+        trackIdArray.push(item.track.id)
       })
 
       /* receive track audio features for each track and store in an array */
@@ -53,7 +56,6 @@ function PlaylistView({
         loudness: 0,
         mode: 0,
         speechiness: 0,
-        tempo: 0,
         time_signature: 0,
         valence: 0
       }
@@ -63,9 +65,7 @@ function PlaylistView({
         // eslint-disable-next-line no-loop-func
         data.audio_features.forEach(item => {
           if (item !== null) {
-            Object.keys(tempTrackVector).forEach(key => {
-              tempTrackVector[key] += item[key]
-            })
+            similar.createTrackObject(tempTrackVector, item)
           } else {
             trackArrayLength -= 1
           }
@@ -100,6 +100,7 @@ function PlaylistView({
              selected={selected}
              setSelected={setSelected}
              setCurrentAddPlaylist={setCurrentAddPlaylist}
+             refresh={refresh}
            />
           ) : <ReactLoading color='#B1A8A6' type='spin' className='loading'/>}
           <Tooltip title='Add Playlist'>

--- a/client/src/components/Track/Track.css
+++ b/client/src/components/Track/Track.css
@@ -41,7 +41,6 @@
 }
 
 #add {
-  /* padding: 10px; */
   border: 1px solid var(--light-border);
   border-radius: 7px;
   cursor: pointer;

--- a/client/src/components/Track/Track.css
+++ b/client/src/components/Track/Track.css
@@ -41,6 +41,7 @@
 }
 
 #add {
+  /* padding: 10px; */
   border: 1px solid var(--light-border);
   border-radius: 7px;
   cursor: pointer;

--- a/client/src/components/TrackContainer/TrackContainer.css
+++ b/client/src/components/TrackContainer/TrackContainer.css
@@ -1,7 +1,7 @@
 .track-container {
   width: 100%;
   padding: 20px 30px 30px 30px;
-  border: 1px solid black;
+  background: var(--background-color);
   border-radius: 10px;
 }
 

--- a/client/src/components/TrackContainer/TrackContainer.jsx
+++ b/client/src/components/TrackContainer/TrackContainer.jsx
@@ -29,9 +29,8 @@ function TrackContainer({
       const allTracks = await track.getAllPlaylistTracks(playlistId)
 
       /* gets track audio features for each track */
-      let trackIdArray = []
-      allTracks.forEach(item => {
-        trackIdArray.push(item.track.id)
+      const trackIdArray = allTracks.map(item => {
+        return item.track.id
       })
 
       /* initialize tracks array */

--- a/client/src/components/TrackContainer/TrackContainer.jsx
+++ b/client/src/components/TrackContainer/TrackContainer.jsx
@@ -40,7 +40,6 @@ function TrackContainer({
       while (trackIdArray.length > 0) {
         let trackIdString = trackIdArray.splice(0, 100).join(',')
         const { data } = await getTracksAudioFeatures(trackIdString)
-        console.log(data.audio_features)
         data.audio_features.forEach(item => {
           let tempTrackVector = {
             acousticness: 0,
@@ -58,7 +57,6 @@ function TrackContainer({
           if (item !== null) {
             similar.createTrackObject(tempTrackVector, item)
             const trackVectorArray = similar.convertObjectToVector(tempTrackVector)
-            console.log(trackVectorArray)
             
             let similarity = 0
             if (similarityMethod === 0) {
@@ -66,13 +64,10 @@ function TrackContainer({
             } else {
               similarity = similar.calculateOwnSimilarity(vector, trackVectorArray)
             }
-            console.log(similarity)
-            console.log(item.id)
             tempTracks.push({ id: item.id, similarity: similarity})
           }
         })
       }
-      console.log(tempTracks)
     }
     getAllTracks()
   }, [])
@@ -80,16 +75,6 @@ function TrackContainer({
   return (
     <div className="track-container">
       <div className="tracks">
-        {/* {tracks.map((item, idx) => (
-          <Track 
-            key={idx} 
-            track={item.track} 
-            trackNumber={idx}
-            addPlaylist={addPlaylist}
-            playlistId={originalPlaylistId}
-            similarityMethod={similarityMethod}
-          />
-        ))} */}
       </div>
       <ToastContainer
         position="top-center"

--- a/client/src/utils/playlist.js
+++ b/client/src/utils/playlist.js
@@ -97,11 +97,3 @@ export const removeFavoritePlaylist = (playlistId) => {
     }
   })
 }
-
-export const sortOptionsTracks = (options) => {
-  options.sort((a, b) => {
-    if(a.label.toLowerCase() < b.label.toLowerCase()) { return -1; }
-    if(a.label.toLowerCase() > b.label.toLowerCase()) { return 1; }
-    return 0;
-  })
-}

--- a/client/src/utils/spotify.js
+++ b/client/src/utils/spotify.js
@@ -106,6 +106,10 @@ export const getPlaylistDetail = (playlistId) => {
   return instance.get(`/playlists/${playlistId}`)
 }
 
+export const getPlaylistItems = (playlistId, offset) => {
+  return axios.get(`/playlists/${playlistId}/tracks?limit=50&offset=${offset}`)
+}
+
 export const getTrackDetail = (trackId) => {
   return instance.get(`/tracks/${trackId}`)
 }

--- a/client/src/utils/tracks.js
+++ b/client/src/utils/tracks.js
@@ -1,0 +1,25 @@
+import { getPlaylistItems } from "./spotify";
+
+export default class Tracks {
+  sortOptionsTracks = (options) => {
+    options.sort((a, b) => {
+      if(a.label.toLowerCase() < b.label.toLowerCase()) { return -1; }
+      if(a.label.toLowerCase() > b.label.toLowerCase()) { return 1; }
+      return 0;
+    })
+  }
+
+  getAllPlaylistTracks = async (playlistId) => {
+    let allTracks = []
+    let offset = 0
+    let tracks = await getPlaylistItems(playlistId, offset)
+    tracks.data.items.forEach(item => allTracks.push(item))
+    
+    while (tracks.data.items.length > 0) {
+      offset += tracks.data.items.length
+      tracks = await getPlaylistItems(playlistId, offset)
+      tracks.data.items.forEach(item => allTracks.push(item))
+    }
+    return allTracks
+  }
+}

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,1 +1,2 @@
 .env
+**/node_modules


### PR DESCRIPTION
What
===
* switch to making batch requests for track data instead of individual calls
* moved genre section into own component
* updated playlist card/detail UI

Why
===
* does not exceed Spotify API's request rate when playlist contains a lot of tracks
* make recommend-view component smaller and organized

Who
===
@makushline @qibolun 

Test Plan
===
<img width="1552" alt="Screen Shot 2022-07-26 at 10 16 36 AM" src="https://user-images.githubusercontent.com/90161607/181069830-b83b1e4c-ca69-436f-bdfd-8fa6efc919e1.png">